### PR TITLE
fix(client/outfits): remove checkbox and check if string is not empty

### DIFF
--- a/client/outfits.lua
+++ b/client/outfits.lua
@@ -102,11 +102,13 @@ AddEventHandler('ox_appearance:saveOutfit', function(data)
 		end
 	else
 		local input = lib.inputDialog(locale('update', data.name), {
-			{ type = 'input', label = locale('outfit_name') },
-			{ type = 'checkbox', label = locale('confirm') },
+			{ type = 'input', label = locale('outfit_name') }
 		})
 
-		if input and input[2] then
+		if input then
+			if input[1]:len() < 1 then
+				return lib.notify({ type = 'error', description = locale('invalid_name') })
+			end
 			local appearance = exports['fivem-appearance']:getPedAppearance(cache.ped)
 			outfitNames[data.slot] = input[1] or data.name
 			outfits[data.slot] = appearance

--- a/locales/en.json
+++ b/locales/en.json
@@ -6,6 +6,7 @@
     "wear": "Wear %s",
     "update": "Update %s",
     "outfit_name": "Outfit Name",
+    "invalid_name": "Name is not valid",
     "new_outfit": "New Outfit",
     "rename_outfit": "Rename Outfit",
     "confirm": "Confirm",


### PR DESCRIPTION
The confirm checkbox is useless since the inputDialog already have Confirm and Cancel buttons.

Before:
![image1](https://user-images.githubusercontent.com/47056777/215364946-8a78e277-2b1a-48c2-b626-debedf85b3dc.png)

After:
![image2](https://user-images.githubusercontent.com/47056777/215364975-fd59ee8c-dfd5-4289-8039-e4d2bded6435.png)
